### PR TITLE
docs(README): fix outdated link to new location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DesignSafe Use Case Template
 
 > [!WARNING]
-> **Deprecated.** Content migrated to [DesignSafe-CI/**DS-User-Guide**:`/user-guide/usecases`](https://github.com/DesignSafe-CI/DS-User-Guide/tree/main/user-guide/docs/usecases#readme). To contribute, follow [its README](https://github.com/DesignSafe-CI/DS-User-Guide/tree/main/user-guide/usecases#readme).
+> **Deprecated.** Content migrated to [DesignSafe-CI/**DS-User-Guide**:`/user-guide/usecases`](https://github.com/DesignSafe-CI/DS-User-Guide/tree/main/user-guide/usecases#readme).
 
 > [!IMPORTANT]
 > If your content is not available or accurate there, please migrate it to or update it there.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DesignSafe Use Case Template
 
 > [!WARNING]
-> **Deprecated.** Content migrated to [DesignSafe-CI/**DS-User-Guide**:`/user-guide/docs/usecases`](https://github.com/DesignSafe-CI/DS-User-Guide/tree/main/user-guide/docs/usecases#readme). To contribute, follow [its README](https://github.com/DesignSafe-CI/DS-User-Guide/tree/main/user-guide/docs/usecases#readme).
+> **Deprecated.** Content migrated to [DesignSafe-CI/**DS-User-Guide**:`/user-guide/usecases`](https://github.com/DesignSafe-CI/DS-User-Guide/tree/main/user-guide/docs/usecases#readme). To contribute, follow [its README](https://github.com/DesignSafe-CI/DS-User-Guide/tree/main/user-guide/usecases#readme).
 
 > [!IMPORTANT]
-> If your content is not available or accurate there, please open a PR to migrate or update it.
+> If your content is not available or accurate there, please migrate it to or update it there.


### PR DESCRIPTION
The link should not have a `/docs/` anymore.

New link: https://github.com/DesignSafe-CI/DS-User-Guide/tree/main/user-guide/usecases#readme